### PR TITLE
Feature/customize pin

### DIFF
--- a/src/components/Pin/index.js
+++ b/src/components/Pin/index.js
@@ -130,8 +130,20 @@ class Pin extends PureComponent {
         const { pin } = this.state;
         return (
             <Wrapper>
-                <H2>Enter { device.label } PIN</H2>
-                <P isSmaller>The PIN layout is displayed on your Trezor.</P>
+                {
+                    this.props.header ? (
+                        <React.Fragment>
+                            {this.props.header}
+                        </React.Fragment>
+                        )
+                    : (
+                        <React.Fragment>
+                            <H2>Enter { device.label } PIN</H2>
+                            <P isSmaller>The PIN layout is displayed on your Trezor.</P>
+                        </React.Fragment>
+                    )
+                }
+                
                 <InputRow>
                     <PinInput value={pin} onDeleteClick={() => this.onPinBackspace()} />
                 </InputRow>

--- a/src/components/Pin/index.js
+++ b/src/components/Pin/index.js
@@ -180,6 +180,7 @@ class Pin extends PureComponent {
 Pin.propTypes = {
     device: PropTypes.object.isRequired,
     onPinSubmit: PropTypes.func.isRequired,
+    header: PropTypes.object,
 };
 
 export default Pin;


### PR DESCRIPTION
We need more customizable PIN component. For example if it should be used for pin setup - enter a new PIN and re-enter it to confirm). 

This could be done in two ways
1. Add prop that would be a component customizing selected area (included in this PR)
1. Split this component to more subcomponents and then create wrapper components for specific usecases

Dunno which one is better. 

Btw. by using React.Fragment (which shouldnt be required I think) I am bypassing reacts `prop key is required` error. It might be caused by improper babel configuration as stated here https://github.com/facebook/react/issues/10352 