### PR TITLE
Fix/Tooltip: pass ...rest props, call-to-action button text

### DIFF
--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -18,13 +18,22 @@ const ContentWrapper = styled.div`
     display: block;
 `;
 
-const ReadMore = styled.div`
+const CTAWrapper = styled.div`
     margin-top: 15px;
     padding: 10px 0 5px 0;
     text-align: center;
     width: 100%;
-    color: ${colors.WHITE};
     border-top: 1px solid ${colors.TEXT_SECONDARY};
+`;
+
+const StyledLink = styled(Link)`
+    &,
+    &:visited,
+    &:active,
+    &:hover {
+        color: ${colors.WHITE};
+        text-decoration: none;
+    }
 `;
 
 class Tooltip extends React.Component {
@@ -34,14 +43,23 @@ class Tooltip extends React.Component {
     }
 
     render() {
-        const { maxWidth, className, placement, content, readMoreLink, children } = this.props;
+        const {
+            maxWidth,
+            className,
+            placement,
+            content,
+            ctaText,
+            ctaLink,
+            children,
+            ...rest
+        } = this.props;
         const Overlay = (
             <ContentWrapper>
                 <Content maxWidth={maxWidth}>{content}</Content>
-                {readMoreLink && (
-                    <Link href={readMoreLink}>
-                        <ReadMore>Read more</ReadMore>
-                    </Link>
+                {ctaLink && (
+                    <StyledLink isGray href={ctaLink}>
+                        <CTAWrapper>{ctaText}</CTAWrapper>
+                    </StyledLink>
                 )}
             </ContentWrapper>
         );
@@ -58,6 +76,7 @@ class Tooltip extends React.Component {
                     arrowContent={<div className="rc-tooltip-arrow-inner" />}
                     placement={placement}
                     overlay={() => Overlay}
+                    {...rest}
                 >
                     {children}
                 </RcTooltip>
@@ -72,7 +91,8 @@ Tooltip.propTypes = {
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     maxWidth: PropTypes.number,
     content: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-    readMoreLink: PropTypes.string,
+    ctaLink: PropTypes.string,
+    ctaText: PropTypes.string,
 };
 
 export default Tooltip;

--- a/src/stories/components/text.js
+++ b/src/stories/components/text.js
@@ -264,7 +264,8 @@ storiesOf('Typography', module)
                     'Content',
                     'Passphrase is an optional feature of the Trezor device that is recommended for advanced users only. It is a word or a sentence of your choice. Its main purpose is to access a hidden wallet.'
                 )}
-                readMoreLink={text('Read more link', 'https://wiki.trezor.io/Passphrase')}
+                ctaLink={text('CTA link', 'https://wiki.trezor.io/Passphrase')}
+                ctaText={text('CTA Text', 'Learn more')}
             >
                 <span>Text with tooltip</span>
             </Tooltip>
@@ -276,6 +277,7 @@ storiesOf('Typography', module)
             ~~~js
             import { Tooltip } from 'trezor-ui-components';
             ~~~
+            *<Tooltip> is a wrapper around [rc-tooltip](https://github.com/react-component/tooltip) component. See the [official documentation](https://github.com/react-component/tooltip) for more information about its props and usage.*
             `,
             },
         }


### PR DESCRIPTION
- passing all props to rc-tooltip
- renamed `readMoreLink` to `ctaLink` (call-to-actionLink), text of the cat button now passed as prop `ctaText` to allow localization
- updated docs