### PR TITLE
Fix/Notifications cta button now wraps on new line

### DIFF
--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -15,8 +15,8 @@ const Wrapper = styled.div`
     position: relative;
     display: flex;
     justify-content: center;
-    color: ${props => getPrimaryColor(props.type)};
-    background: ${props => getNotificationBgColor(props.type)};
+    color: ${props => getPrimaryColor(props.variant)};
+    background: ${props => getNotificationBgColor(props.variant)};
 `;
 
 const Content = styled.div`
@@ -96,14 +96,14 @@ const Notification = props => {
     const close = typeof props.close === 'function' ? props.close : () => {}; // TODO: add default close action
 
     return (
-        <Wrapper className={props.className} type={props.type}>
+        <Wrapper className={props.className} variant={props.variant}>
             <Content>
                 <Col>
                     <Body>
                         <IconWrapper>
                             <StyledIcon
-                                color={getPrimaryColor(props.type)}
-                                icon={getStateIcon(props.type)}
+                                color={getPrimaryColor(props.variant)}
+                                icon={getStateIcon(props.variant)}
                                 size={16}
                             />
                         </IconWrapper>
@@ -119,7 +119,7 @@ const Notification = props => {
                                     <ButtonNotification
                                         isInverse
                                         key={action.label}
-                                        variant={props.type}
+                                        variant={props.variant}
                                         isLoading={props.isActionInProgress}
                                         onClick={() => {
                                             close();
@@ -135,7 +135,7 @@ const Notification = props => {
                 </Col>
                 {props.cancelable && (
                     <CloseClick onClick={() => close()}>
-                        <Icon color={getPrimaryColor(props.type)} icon={icons.CLOSE} size={10} />
+                        <Icon color={getPrimaryColor(props.variant)} icon={icons.CLOSE} size={10} />
                     </CloseClick>
                 )}
             </Content>
@@ -145,7 +145,7 @@ const Notification = props => {
 
 Notification.propTypes = {
     close: PropTypes.func,
-    type: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
+    variant: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
     title: PropTypes.node,
     message: PropTypes.node,
     cancelable: PropTypes.bool,

--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -22,15 +22,24 @@ const Wrapper = styled.div`
 const Content = styled.div`
     width: 100%;
     max-width: 1170px;
-    padding: 24px;
+    padding: 24px 24px 14px 24px;
     display: flex;
     flex-direction: row;
     text-align: left;
     align-items: center;
 `;
 
+const Col = styled.div`
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    align-self: flex-start;
+`;
+
 const Body = styled.div`
     display: flex;
+    flex: 1 1 auto;
+    padding-bottom: 10px;
 `;
 
 const Message = styled.div`
@@ -68,7 +77,9 @@ const AdditionalContent = styled.div`
     display: flex;
     justify-content: flex-end;
     align-items: flex-end;
-    flex: 1;
+    flex: 1 1 auto;
+    padding-left: 30px;
+    padding-bottom: 10px;
 `;
 
 const ActionContent = styled.div`
@@ -87,39 +98,41 @@ const Notification = props => {
     return (
         <Wrapper className={props.className} type={props.type}>
             <Content>
-                <Body>
-                    <IconWrapper>
-                        <StyledIcon
-                            color={getPrimaryColor(props.type)}
-                            icon={getStateIcon(props.type)}
-                            size={16}
-                        />
-                    </IconWrapper>
-                    <Texts>
-                        <Title>{props.title}</Title>
-                        {props.message ? <Message>{props.message}</Message> : ''}
-                    </Texts>
-                </Body>
-                <AdditionalContent>
-                    {props.actions && props.actions.length > 0 && (
-                        <ActionContent>
-                            {props.actions.map(action => (
-                                <ButtonNotification
-                                    isInverse
-                                    key={action.label}
-                                    variant={props.type}
-                                    isLoading={props.isActionInProgress}
-                                    onClick={() => {
-                                        close();
-                                        action.callback();
-                                    }}
-                                >
-                                    {action.label}
-                                </ButtonNotification>
-                            ))}
-                        </ActionContent>
-                    )}
-                </AdditionalContent>
+                <Col>
+                    <Body>
+                        <IconWrapper>
+                            <StyledIcon
+                                color={getPrimaryColor(props.type)}
+                                icon={getStateIcon(props.type)}
+                                size={16}
+                            />
+                        </IconWrapper>
+                        <Texts>
+                            <Title>{props.title}</Title>
+                            {props.message ? <Message>{props.message}</Message> : ''}
+                        </Texts>
+                    </Body>
+                    <AdditionalContent>
+                        {props.actions && props.actions.length > 0 && (
+                            <ActionContent>
+                                {props.actions.map(action => (
+                                    <ButtonNotification
+                                        isInverse
+                                        key={action.label}
+                                        variant={props.type}
+                                        isLoading={props.isActionInProgress}
+                                        onClick={() => {
+                                            close();
+                                            action.callback();
+                                        }}
+                                    >
+                                        {action.label}
+                                    </ButtonNotification>
+                                ))}
+                            </ActionContent>
+                        )}
+                    </AdditionalContent>
+                </Col>
                 {props.cancelable && (
                     <CloseClick onClick={() => close()}>
                         <Icon color={getPrimaryColor(props.type)} icon={icons.CLOSE} size={10} />

--- a/src/stories/components/notifications.js
+++ b/src/stories/components/notifications.js
@@ -3,6 +3,8 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
+import { linkTo } from '@storybook/addon-links';
+import { H1, H5 } from 'components/Heading';
 
 import styled from 'styled-components';
 
@@ -10,9 +12,201 @@ import Notification from 'components/Notification';
 import colors from 'config/colors';
 
 const Wrapper = styled.div`
-    min-width: 600px;
+    padding: 1.6rem;
+`;
+
+const StyledNotification = styled(Notification)``;
+
+const Row = styled.div`
+    display: flex;
+    margin: 0.5rem 0 2rem;
+    flex-wrap: wrap;
+
+    ${StyledNotification} {
+        margin: 10px 0px;
+    }
+`;
+
+const BtnLink = styled.button`
+    font-size: 1rem;
+    color: ${colors.TEXT_SECONDARY};
+    vertical-align: middle;
+    background: ${colors.LANDING};
+    padding: 0.5rem;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+
+    &:hover {
+        color: ${colors.TEXT};
+    }
 `;
 Wrapper.displayName = 'Wrapper';
+
+const notMessage = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Etiam sapien elit.';
+
+storiesOf('Notifications', module).add('All', () => (
+    <Wrapper>
+        <H1>
+            Basic{' '}
+            <BtnLink onClick={linkTo('Notifications', 'Notification')}>
+                {'<Notification />'}
+            </BtnLink>
+        </H1>
+        <Row>
+            <StyledNotification type="info" title="Notification title" message={notMessage} />
+            <StyledNotification type="success" title="Notification title" message={notMessage} />
+            <StyledNotification type="warning" title="Notification title" message={notMessage} />
+            <StyledNotification type="error" title="Notification title" message={notMessage} />
+        </Row>
+        <Row />
+
+        <H5>cancellable </H5>
+        <Row>
+            <StyledNotification
+                type="info"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+            />
+            <StyledNotification
+                type="success"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+            />
+            <StyledNotification
+                type="warning"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+            />
+            <StyledNotification
+                type="error"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+            />
+        </Row>
+        <H5>
+            with an action button
+            <BtnLink onClick={linkTo('Notifications', 'Notification with CTA')}>
+                {'<Notification actions={[...]} cancelable/>'}
+            </BtnLink>
+        </H5>
+        <Row>
+            <StyledNotification
+                type="info"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+                actions={[
+                    {
+                        label: 'Call To Action',
+                        callback: () => {},
+                    },
+                ]}
+            />
+            <StyledNotification
+                type="success"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+                actions={[
+                    {
+                        label: 'Call To Action',
+                        callback: () => {},
+                    },
+                ]}
+            />
+            <StyledNotification
+                type="warning"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+                actions={[
+                    {
+                        label: 'Call To Action',
+                        callback: () => {},
+                    },
+                ]}
+            />
+            <StyledNotification
+                type="error"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+                actions={[
+                    {
+                        label: 'Call To Action',
+                        callback: () => {},
+                    },
+                ]}
+            />
+        </Row>
+
+        <H5>
+            with an action in progress
+            <BtnLink onClick={linkTo('Notifications', 'Notification with CTA')}>
+                {'<Notification actions={[...]} cancelable/>'}
+            </BtnLink>
+        </H5>
+        <Row>
+            <StyledNotification
+                type="info"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+                isActionInProgress
+                actions={[
+                    {
+                        label: 'Call To Action',
+                        callback: () => {},
+                    },
+                ]}
+            />
+            <StyledNotification
+                type="success"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+                isActionInProgress
+                actions={[
+                    {
+                        label: 'Call To Action',
+                        callback: () => {},
+                    },
+                ]}
+            />
+            <StyledNotification
+                type="warning"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+                isActionInProgress
+                actions={[
+                    {
+                        label: 'Call To Action',
+                        callback: () => {},
+                    },
+                ]}
+            />
+            <StyledNotification
+                type="error"
+                title="Notification title"
+                message={notMessage}
+                cancelable
+                isActionInProgress
+                actions={[
+                    {
+                        label: 'Call To Action',
+                        callback: () => {},
+                    },
+                ]}
+            />
+        </Row>
+    </Wrapper>
+));
 
 storiesOf('Notifications', module)
     .addDecorator(
@@ -88,7 +282,7 @@ storiesOf('Notifications', module)
                 cancelable={boolean('Cancelable', false)}
                 actions={[
                     {
-                        label: 'Confirm',
+                        label: 'Create a backup in 3 minutes',
                         callback: () => {},
                     },
                 ]}

--- a/src/stories/components/notifications.js
+++ b/src/stories/components/notifications.js
@@ -54,35 +54,35 @@ storiesOf('Notifications', module).add('All', () => (
             </BtnLink>
         </H1>
         <Row>
-            <StyledNotification type="info" title="Notification title" message={notMessage} />
-            <StyledNotification type="success" title="Notification title" message={notMessage} />
-            <StyledNotification type="warning" title="Notification title" message={notMessage} />
-            <StyledNotification type="error" title="Notification title" message={notMessage} />
+            <StyledNotification variant="info" title="Notification title" message={notMessage} />
+            <StyledNotification variant="success" title="Notification title" message={notMessage} />
+            <StyledNotification variant="warning" title="Notification title" message={notMessage} />
+            <StyledNotification variant="error" title="Notification title" message={notMessage} />
         </Row>
         <Row />
 
         <H5>cancellable </H5>
         <Row>
             <StyledNotification
-                type="info"
+                variant="info"
                 title="Notification title"
                 message={notMessage}
                 cancelable
             />
             <StyledNotification
-                type="success"
+                variant="success"
                 title="Notification title"
                 message={notMessage}
                 cancelable
             />
             <StyledNotification
-                type="warning"
+                variant="warning"
                 title="Notification title"
                 message={notMessage}
                 cancelable
             />
             <StyledNotification
-                type="error"
+                variant="error"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -96,7 +96,7 @@ storiesOf('Notifications', module).add('All', () => (
         </H5>
         <Row>
             <StyledNotification
-                type="info"
+                variant="info"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -108,7 +108,7 @@ storiesOf('Notifications', module).add('All', () => (
                 ]}
             />
             <StyledNotification
-                type="success"
+                variant="success"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -120,7 +120,7 @@ storiesOf('Notifications', module).add('All', () => (
                 ]}
             />
             <StyledNotification
-                type="warning"
+                variant="warning"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -132,7 +132,7 @@ storiesOf('Notifications', module).add('All', () => (
                 ]}
             />
             <StyledNotification
-                type="error"
+                variant="error"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -153,7 +153,7 @@ storiesOf('Notifications', module).add('All', () => (
         </H5>
         <Row>
             <StyledNotification
-                type="info"
+                variant="info"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -166,7 +166,7 @@ storiesOf('Notifications', module).add('All', () => (
                 ]}
             />
             <StyledNotification
-                type="success"
+                variant="success"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -179,7 +179,7 @@ storiesOf('Notifications', module).add('All', () => (
                 ]}
             />
             <StyledNotification
-                type="warning"
+                variant="warning"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -192,7 +192,7 @@ storiesOf('Notifications', module).add('All', () => (
                 ]}
             />
             <StyledNotification
-                type="error"
+                variant="error"
                 title="Notification title"
                 message={notMessage}
                 cancelable
@@ -233,7 +233,7 @@ storiesOf('Notifications', module)
         'Notification',
         () => {
             const type = select(
-                'Type',
+                'Variant',
                 {
                     Success: 'success',
                     Warning: 'warning',
@@ -247,9 +247,9 @@ storiesOf('Notifications', module)
             const cancelable = boolean('Cancelable', false);
 
             if (cancelable) {
-                return <Notification type={type} title={title} message={message} cancelable />;
+                return <Notification variant={type} title={title} message={message} cancelable />;
             }
-            return <Notification type={type} title={title} message={message} />;
+            return <Notification variant={type} title={title} message={message} />;
         },
         {
             info: {
@@ -266,8 +266,8 @@ storiesOf('Notifications', module)
         'Notification with CTA',
         () => (
             <Notification
-                type={select(
-                    'Type',
+                variant={select(
+                    'Variant',
                     {
                         Success: 'success',
                         Warning: 'warning',


### PR DESCRIPTION
- CTA button wraps on new line on long notification's message
- renamed prop `type` to `variant` (https://github.com/trezor/trezor-ui-components/issues/72)
- added storybook page with all notifications (and their props) displayed

closes https://github.com/trezor/trezor-ui-components/issues/146

**This PR is based on another feature branch, merge https://github.com/trezor/trezor-ui-components/pull/184 first**