### PR TITLE
Fix/Rename Inputs prop "trezorAction" to "tooltipAction"

### DIFF
--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -119,7 +119,7 @@ const TooltipAction = styled.div`
     display: ${props => (props.action ? 'flex' : 'none')};
     align-items: center;
     margin: 0px 10px;
-    padding: 0 14px 0 5px;
+    padding: 0 14px;
     position: absolute;
     background: black;
     bottom: -25px;

--- a/src/components/Textarea/index.js
+++ b/src/components/Textarea/index.js
@@ -97,13 +97,9 @@ const StyledTextarea = styled(Textarea)`
     }
 
     ${props =>
-        props.trezorAction &&
+        props.tooltipAction &&
         css`
             z-index: 10001; /* bigger than modal container */
-            border-color: ${colors.WHITE};
-            border-width: 2px;
-            transform: translate(-1px, -1px);
-            background: ${colors.DIVIDER};
             pointer-events: none;
         `}
 `;
@@ -119,7 +115,7 @@ const BottomText = styled.span`
     margin-top: 10px;
 `;
 
-const TrezorAction = styled.div`
+const TooltipAction = styled.div`
     display: ${props => (props.action ? 'flex' : 'none')};
     align-items: center;
     margin: 0px 10px;
@@ -171,10 +167,10 @@ class TextArea extends PureComponent {
                     onChange={this.props.onChange}
                     border={getPrimaryColor(this.props.state)}
                 />
-                <TrezorAction action={this.props.trezorAction}>
+                <TooltipAction action={this.props.tooltipAction}>
                     <ArrowUp />
-                    {this.props.trezorAction}
-                </TrezorAction>
+                    {this.props.tooltipAction}
+                </TooltipAction>
                 {this.props.bottomText && (
                     <BottomText color={getPrimaryColor(this.props.state)}>
                         {this.props.bottomText}
@@ -203,7 +199,7 @@ TextArea.propTypes = {
     state: PropTypes.oneOf(['success', 'warning', 'error']),
     autoSelect: PropTypes.bool,
     bottomText: PropTypes.string,
-    trezorAction: PropTypes.node,
+    tooltipAction: PropTypes.node,
 };
 
 export default TextArea;

--- a/src/components/inputs/Input/index.js
+++ b/src/components/inputs/Input/index.js
@@ -75,14 +75,10 @@ const StyledInput = styled.input`
     }
 
     ${props =>
-        props.trezorAction &&
+        props.tooltipAction &&
         css`
-            z-index: 10001;
-            position: relative; /* bigger than modal container */
-            border-color: ${colors.WHITE};
-            border-width: 2px;
-            transform: translate(-1px, -1px);
-            background: ${colors.DIVIDER};
+            z-index: 10001; /* bigger than modal container */
+            position: relative;
         `};
 `;
 
@@ -117,8 +113,8 @@ const Overlay = styled.div`
         `}
 `;
 
-const TrezorAction = styled.div`
-    display: ${props => (props.action ? 'flex' : 'none')};
+const TooltipAction = styled.div`
+    display: ${props => (props.tooltipAction ? 'flex' : 'none')};
     align-items: center;
     height: 37px;
     margin: 0px 10px;
@@ -164,8 +160,8 @@ class Input extends PureComponent {
                         <StyledInput
                             autoComplete="off"
                             height={this.props.height}
-                            trezorAction={this.props.trezorAction}
-                            hasIcon={this.props.icon || getStateIcon(this.props.state)}
+                            tooltipAction={this.props.tooltipAction}
+                            hasIcon={this.props.icon || this.getStateIcon(this.props.state)}
                             ref={this.props.innerRef}
                             hasAddon={!!this.props.sideAddons}
                             type={this.props.type}
@@ -184,10 +180,10 @@ class Input extends PureComponent {
                             name={this.props.name}
                             data-lpignore="true"
                         />
-                        <TrezorAction action={this.props.trezorAction}>
+                        <TooltipAction tooltipAction={this.props.tooltipAction}>
                             <ArrowUp />
-                            {this.props.trezorAction}
-                        </TrezorAction>
+                            {this.props.tooltipAction}
+                        </TooltipAction>
                     </InputIconWrapper>
                     {this.props.sideAddons && this.props.sideAddons.map(sideAddon => sideAddon)}
                 </InputWrapper>
@@ -218,7 +214,7 @@ Input.propTypes = {
     state: PropTypes.oneOf(['success', 'warning', 'error']),
     bottomText: PropTypes.node,
     topLabel: PropTypes.node,
-    trezorAction: PropTypes.node,
+    tooltipAction: PropTypes.node,
     sideAddons: PropTypes.arrayOf(PropTypes.node),
     isDisabled: PropTypes.bool,
     name: PropTypes.string,

--- a/src/components/inputs/Input/index.js
+++ b/src/components/inputs/Input/index.js
@@ -161,7 +161,7 @@ class Input extends PureComponent {
                             autoComplete="off"
                             height={this.props.height}
                             tooltipAction={this.props.tooltipAction}
-                            hasIcon={this.props.icon || this.getStateIcon(this.props.state)}
+                            hasIcon={this.props.icon || getStateIcon(this.props.state)}
                             ref={this.props.innerRef}
                             hasAddon={!!this.props.sideAddons}
                             type={this.props.type}

--- a/src/components/inputs/Input/index.js
+++ b/src/components/inputs/Input/index.js
@@ -114,7 +114,7 @@ const Overlay = styled.div`
 `;
 
 const TooltipAction = styled.div`
-    display: ${props => (props.tooltipAction ? 'flex' : 'none')};
+    display: ${props => (props.action ? 'flex' : 'none')};
     align-items: center;
     height: 37px;
     margin: 0px 10px;
@@ -180,7 +180,7 @@ class Input extends PureComponent {
                             name={this.props.name}
                             data-lpignore="true"
                         />
-                        <TooltipAction tooltipAction={this.props.tooltipAction}>
+                        <TooltipAction action={this.props.tooltipAction}>
                             <ArrowUp />
                             {this.props.tooltipAction}
                         </TooltipAction>

--- a/src/components/inputs/Input/index.js
+++ b/src/components/inputs/Input/index.js
@@ -118,7 +118,7 @@ const TooltipAction = styled.div`
     align-items: center;
     height: 37px;
     margin: 0px 10px;
-    padding: 0 14px 0 5px;
+    padding: 0 14px;
     position: absolute;
     top: 45px;
     background: black;

--- a/src/stories/components/form.js
+++ b/src/stories/components/form.js
@@ -71,6 +71,7 @@ storiesOf('Form', module)
                     bottomText={bottomText}
                     topLabel={topLabel}
                     onChange={() => {}}
+                    tooltipAction={text('tooltipAction', '')}
                     {...(state ? { state } : {})}
                     {...(isDisabled ? { isDisabled } : {})}
                 />

--- a/src/stories/components/form.js
+++ b/src/stories/components/form.js
@@ -71,7 +71,7 @@ storiesOf('Form', module)
                     bottomText={bottomText}
                     topLabel={topLabel}
                     onChange={() => {}}
-                    tooltipAction={text('tooltipAction', '')}
+                    tooltipAction={text('tooltipAction', undefined)}
                     {...(state ? { state } : {})}
                     {...(isDisabled ? { isDisabled } : {})}
                 />
@@ -119,7 +119,7 @@ storiesOf('Form', module)
                     placeholder={text('Placeholder', 'placeholder...')}
                     bottomText={text('Bottom text', 'bottom text')}
                     topLabel={text('Top label', 'Textarea label')}
-                    tooltipAction={text('tooltipAction', '')}
+                    tooltipAction={text('tooltipAction', undefined)}
                     {...(isDisabled ? { isDisabled } : {})}
                     {...(state ? { state } : {})} // hack to hide state prop if its value is null
                 />

--- a/src/stories/components/form.js
+++ b/src/stories/components/form.js
@@ -119,6 +119,7 @@ storiesOf('Form', module)
                     placeholder={text('Placeholder', 'placeholder...')}
                     bottomText={text('Bottom text', 'bottom text')}
                     topLabel={text('Top label', 'Textarea label')}
+                    tooltipAction={text('tooltipAction', '')}
                     {...(isDisabled ? { isDisabled } : {})}
                     {...(state ? { state } : {})} // hack to hide state prop if its value is null
                 />


### PR DESCRIPTION
- rename prop `trezorAction` to `tooltipAction` to make it hw wallet agnostic 😀
- added this prop to storybook's knobs
- deleted some weird style 🙏
closes https://github.com/trezor/trezor-ui-components/issues/85

<img width="699" alt="Screenshot 2019-05-01 at 15 23 20" src="https://user-images.githubusercontent.com/6961901/57018860-35941e00-6c25-11e9-874a-1b368ca97c35.png">